### PR TITLE
Fix typo in writeExtensionProperties

### DIFF
--- a/src/main/java/com/yinzara/jasperreports/fonts/maven/plugin/FontsMojo.java
+++ b/src/main/java/com/yinzara/jasperreports/fonts/maven/plugin/FontsMojo.java
@@ -458,7 +458,7 @@ public class FontsMojo extends org.apache.maven.plugin.AbstractMojo {
         OutputStreamWriter writer = null;
         try {
             writer = new OutputStreamWriter(new FileOutputStream(extensionPropertiesFile));
-            writer.write("net.sf.jasperreports.extension.registry.factory.font="
+            writer.write("net.sf.jasperreports.extension.registry.factory.fonts="
                     + "net.sf.jasperreports.engine.fonts.SimpleFontExtensionsRegistryFactory\n");
             writer.write("net.sf.jasperreports.extension.simple.font.families.fonts=");
             writer.write(xmlFileName);


### PR DESCRIPTION
This is apparently a typo. I didn't look at Jasper sourcecode or docs (sorry), but a Google Search for `net.sf.jasperreports.extension.registry.factory.font` only returns 2 results (both related to jasperreports-fonts-maven-plugin), whereas a Google Search for `net.sf.jasperreports.extension.registry.factory.fonts` returns 176 results.
